### PR TITLE
Final changes to Form Submission and AddQuestion

### DIFF
--- a/api/SharedCode/models/Forms.js
+++ b/api/SharedCode/models/Forms.js
@@ -87,7 +87,7 @@ async function AddQuestion({ text, type }){
     return new Promise(async resolve => {
         const now = new Date();
         const newQuestion = {
-            priority:50,
+            priority:20,
             id: await tb.genId(),
             text,
             type,

--- a/api/SharedCode/services/Forms.js
+++ b/api/SharedCode/services/Forms.js
@@ -103,10 +103,11 @@ async function AddSubmission(input) {
       let success;
   
       const authorized = await Authorize(token, AUTH_ROLES.Staff);
+      const adminCheck = await Authorize(token, AUTH_ROLES.Admin);
       if (!authorized) {
         return new Reply({ point: "Authorization" });
       }
-      if(data[otherIdIndex].value !="Myself"){
+      if(data[otherIdIndex].value !="Myself" && adminCheck === true){//If the admin check fails, even if they are trying to submit for someone else, it will default to submitting for themselves.
                 newID = data[otherIdIndex].value
                 delete data[otherIdIndex]//Remove the inserted extra identifier to make sure it causes no problems in Model
                 success = await model.AddSubmission({


### PR DESCRIPTION
Added an additional condition to submitting forms that even if a non admin user tries to submit for someone else it just defaults to themselves no matter what. Even if they change the drop down. 

Changed the default priority of AddQuestion from 50 to 20 because now OrderChange refreshes the page so refreshing 30-40 times to move it down is absurd.